### PR TITLE
Move example sketch to appropriately named folder

### DIFF
--- a/lcd1602a/examples/sample/sample.ino
+++ b/lcd1602a/examples/sample/sample.ino
@@ -46,8 +46,8 @@
 #   error Platform not defined
 #endif // end IDE
 
-#include "lcd1602a/LCD1602A.hpp"
-#include "lcd1602a/LCD1602A.cpp"
+#include <LCD1602A.hpp>
+#include <LCD1602A.cpp>
 
 LCD1602A lcd;
 


### PR DESCRIPTION
This change causes the example sketch to be accessible via the Arduino IDE's **File > Examples >  lcd1602a** menu after the library is installed.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-examples